### PR TITLE
use a repo-stored properties over docker local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .gradle
 build/
 gradle.properties.local
-gradle.properties.ci
 .gradletasknamecache
 secring.kbx
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,11 +2,18 @@ version: 0.2
 
 env:
   shell: bash
+  parameter-store:
+    KEYRINGFILE: 	/drakkar/java-sdk/KEYRINGFILE
+    OSSRH_USER: /drakkar/java-sdk/OSSRH_USER
+    OSSRH_PASSWORD: /drakkar/java-sdk/OSSRH_PASSWORD
+    SIGNING_KEY: /drakkar/java-sdk/SIGNING_KEY
+    SIGNING_PASSPHRASE: /drakkar/java-sdk/SIGNING_PASSPHRASE
 phases:
   pre_build:
     commands:
       - cp /home/gradle/project/* .
-      - mv gradle.properties.local gradle.properties
+      # - mv gradle.properties.local gradle.properties
+      - mv gradle.properties.ci gradle.properties
   build:
     commands:
       - gradle build

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   shell: bash
   parameter-store:
-    KEYRINGFILE: 	/drakkar/java-sdk/KEYRINGFILE
+    KEYRINGFILE: /drakkar/java-sdk/KEYRINGFILE
     OSSRH_USER: /drakkar/java-sdk/OSSRH_USER
     OSSRH_PASSWORD: /drakkar/java-sdk/OSSRH_PASSWORD
     SIGNING_KEY: /drakkar/java-sdk/SIGNING_KEY

--- a/gradle.properties.ci
+++ b/gradle.properties.ci
@@ -1,0 +1,7 @@
+kotlin.code.style=official
+signing.keyId=$SIGNING_KEY
+signing.password=$SIGNING_PASSPHRASE
+signing.secretKeyRingFile=$KEYRINGFILE
+
+ossrhUsername=$OSSRH_USER
+ossrhPassword=$OSSRH_PASSWORD


### PR DESCRIPTION
This is to get away from using the gradle.properties.local that is stored in the docker image for the build
- store a gradle.properties.ci using env vars
- store parameters in AWS Parameter Store
- inject env vars from Parameter Store in buildspec file

IAM changes:
- create policy: parameterstore-drakkar-java-sdk
- attach new policy to role: codebuild-drakkar-sdk-java-service-role